### PR TITLE
JsonWebSocketResponse: replaced yield from with return to fix Error

### DIFF
--- a/aiohttp_json_rpc/base.py
+++ b/aiohttp_json_rpc/base.py
@@ -38,7 +38,7 @@ class JsonWebSocketResponse(aiohttp.web.WebSocketResponse):
     def prepare(self, request):
         self.objects.append(self)
 
-        yield from super().prepare(request)
+        return super().prepare(request)
 
     @asyncio.coroutine
     def close(self, code=1000, message=b''):


### PR DESCRIPTION
Fixed 'NoneType' object has no attribute 'keep_alive' during WebSocket
close.

Signed-off-by: basti2342 <basti@randomprojects.de>