### PR TITLE
JsonRpc: ignore casing of upgrade header value

### DIFF
--- a/aiohttp_json_rpc/rpc.py
+++ b/aiohttp_json_rpc/rpc.py
@@ -132,7 +132,7 @@ class JsonRpc(object):
         if request.method == 'GET':
 
             # handle Websocket
-            if request.headers.get('upgrade', '') == 'websocket':
+            if request.headers.get('upgrade', '').lower() == 'websocket':
                 return (yield from self.handle_websocket_request(request))
 
             # handle GET


### PR DESCRIPTION
I came across this when setting up tests using the test client from aiohttp. The value for the Upgrade header would then be `WEBSOCKET`, which caused the upgrade to fail. I think the value should be interpreted as case-insensitive, but I can't find a definitive source on that.