### PR TITLE
Fix missing WSGI module in non-django env

### DIFF
--- a/aiohttp_json_rpc/pytest.py
+++ b/aiohttp_json_rpc/pytest.py
@@ -3,7 +3,6 @@ import asyncio
 import pytest
 import os
 
-from aiohttp_wsgi import WSGIHandler
 from aiohttp.web import Application
 
 from aiohttp_json_rpc import JsonRpc, JsonRpcClient
@@ -106,6 +105,7 @@ if DJANGO:
     @pytest.yield_fixture
     def django_rpc_context(db, event_loop, unused_tcp_port):
         from aiohttp_json_rpc.auth.django import DjangoAuthBackend
+        from aiohttp_wsgi import WSGIHandler
 
         rpc = JsonRpc(auth_backend=DjangoAuthBackend())
         rpc_route = ('*', '/rpc', rpc)


### PR DESCRIPTION
Global import causes ImportError in client code: when one uses this package and tries to test their code pytest automatically imports the pytest module, which makes everything fail.