### PR TITLE
Make required aiohttp version more permissive

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(name='aiohttp-json-rpc',
       url='https://github.com/pengutronix/aiohttp-json-rpc/',
       author_email='f.scherf@pengutronix.de',
       license='Apache 2.0',
-      install_requires=['aiohttp>=2,<2.1'],
+      install_requires=['aiohttp>=2,<3'],
       packages=find_packages(),
       zip_safe=False,
       entry_points={


### PR DESCRIPTION
aiohttp follows semver meaning that there will be no breaking changes unless major part of version number changes. I'd like this distribution package not keep me from upgrading to required version of the main framework in use.