### PR TITLE
Fix missing license file in wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,7 @@
 [metadata]
 description = Implementation JSON-RPC 2.0 server and client using aiohttp on top of websockets transport
 long_description = file: README.rst
+license_file = LICENSE.txt
 keywords =
     aiohttp
     asyncio


### PR DESCRIPTION
I've missed this bit in prev PR. This ensures that license file is really added into wheel.