### PR TITLE
Fix logic issue for different prefixes in add_methods

### DIFF
--- a/aiohttp_json_rpc/rpc.py
+++ b/aiohttp_json_rpc/rpc.py
@@ -78,17 +78,17 @@ class JsonRpc(object):
             if not type(arg[0]) == str:
                 raise ValueError('prefix has to be str')
 
-            prefix = prefix or arg[0]
+            prefix_ = prefix or arg[0]
             method = arg[1]
 
             if asyncio.iscoroutinefunction(method):
-                self._add_method(method, prefix=prefix)
+                self._add_method(method, prefix=prefix_)
 
             elif type(method) == str:
-                self._add_methods_by_name(method, prefix=prefix)
+                self._add_methods_by_name(method, prefix=prefix_)
 
             else:
-                self._add_methods_from_object(method, prefix=prefix)
+                self._add_methods_from_object(method, prefix=prefix_)
 
     def add_topics(self, *topics):
         for topic in topics:

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -39,6 +39,36 @@ async def test_add_methods(rpc_context):
 
 
 @pytest.mark.asyncio
+async def test_add_methods_diff_prefixes(rpc_context):
+    client1 = await rpc_context.make_client()
+    methods = await client1.get_methods()
+
+    assert 'method1' not in methods
+    assert 'method2' not in methods
+
+    # add methods
+    async def method1(request):
+        pass
+
+    async def method2(request):
+        pass
+
+    rpc_context.rpc.add_methods(
+        ('prefix1', method1),
+        ('prefix2', method2),
+    )
+
+    client2 = await rpc_context.make_client()
+
+    # Do this so we don't rely on internal naming scheme
+    assert any(m.startswith('prefix1') and m.endswith('method1')
+               for m in (await client2.get_methods()))
+
+    assert any(m.startswith('prefix2') and m.endswith('method2')
+               for m in (await client2.get_methods()))
+
+
+@pytest.mark.asyncio
 async def test_call_method(rpc_context):
     async def add(request):
         return request.params[0] + request.params[1]


### PR DESCRIPTION
As it is right now if we try to add multiple methods with different prefixes the first prefix will override all others. This PR fixes that.

Example:
```py
rpc.add_methods(
    ('prefix1', meth1),
    ('prefix2', meth2),
)
```
Right now, `meth2` will be added with a prefix of `prefix1`.