### PR TITLE
Fix issue with class based views

### DIFF
--- a/aiohttp_json_rpc/client.py
+++ b/aiohttp_json_rpc/client.py
@@ -358,7 +358,8 @@ class JsonRpcClientContext:
     ...     pass
     """
 
-    def __init__(self, rpc_url, test_client=None, build_application=None, rpc_cookies=None):
+    def __init__(self, rpc_url, test_client=None, build_application=None,
+                 rpc_cookies=None):
         self._rpc_client = JsonRpcClient()
         self._rpc_url = rpc_url
         self._rpc_cookies = rpc_cookies
@@ -370,8 +371,12 @@ class JsonRpcClientContext:
 
     async def __aenter__(self):
         if self._testing_client:
-            test_server = await self._test_client(await self._build_application())
-            self._rpc_url = URL(f'ws://{test_server.host}:{test_server.port}{self._rpc_url}')
+            test_server = await self._test_client(
+                await self._build_application()
+            )
+            self._rpc_url = URL(
+                f'ws://{test_server.host}:{test_server.port}{self._rpc_url}'
+            )
 
         await self._rpc_client.connect_url(
             url=self._rpc_url,

--- a/aiohttp_json_rpc/rpc.py
+++ b/aiohttp_json_rpc/rpc.py
@@ -296,15 +296,24 @@ class JsonRpc(object):
 
 def unpack_request_args(original_rpc_method):
     @functools.wraps(original_rpc_method)
-    async def rpc_method_wrapper(json_rpc_request):
+    async def rpc_method_wrapper(*args):
+        cls_based_view = True if len(args) == 2 else False
+        rpc_kwargs = {}
+        if cls_based_view:
+            cls_instance = args[0]
+            json_rpc_request = args[1]
+            rpc_args = [cls_instance]
+        else:
+            cls_instance = None
+            json_rpc_request = args[0]
+            rpc_args = []
+
         rpc_call_params = json_rpc_request.params
 
         try:
-            rpc_args = rpc_call_params.get('args', [])
+            rpc_args = [*rpc_args, *rpc_call_params.get('args', [])]
             rpc_kwargs = rpc_call_params.get('kwargs', {})
         except AttributeError:
-            rpc_args = []
-            rpc_kwargs = {}
-
+            pass
         return await original_rpc_method(*rpc_args, **rpc_kwargs)
     return rpc_method_wrapper

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -85,7 +85,7 @@ async def test_call_method(rpc_context):
 
 
 @pytest.mark.asyncio
-async def test_call_method_and_unpack_args(rpc_context):
+async def test_call_method_and_unpack_args(rpc_context, caplog):
     @rpc.unpack_request_args
     async def add_extra(arg1, arg2, extra):
         return str(arg1 + arg2) + ' ' + extra


### PR DESCRIPTION
When decorator `unpack_request_args` was applied to a class based views there was an error, when dispatching args to `origin_rpc_method`. 

Fix #20 