### PR TITLE
Update pypy version on Travis to 5.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ stages:
 python:
 - 3.5
 - &mainstream_python 3.6
-- &pypy3 pypy3.5-5.8.0
+- &pypy3 pypy3.5-5.10.1
 
 env:
 - ""


### PR DESCRIPTION
This allows the tests to pass with aiohttp 3.2.2 :smiley: