### PR TITLE
RFC: add replacement for unpack_request_args using introspection

### DIFF
--- a/aiohttp_json_rpc/__init__.py
+++ b/aiohttp_json_rpc/__init__.py
@@ -1,4 +1,4 @@
-from .decorators import raw_response  # NOQA
+from .decorators import raw_response, validate  # NOQA
 from .client import JsonRpcClient  # NOQA
 from .rpc import JsonRpc  # NOQA
 

--- a/aiohttp_json_rpc/decorators.py
+++ b/aiohttp_json_rpc/decorators.py
@@ -8,3 +8,15 @@ def raw_response(function=None):
         return decorator(function)
 
     return decorator
+
+
+def validate(**kwargs):
+    def decorator(function):
+        if not hasattr(function, 'validators'):
+            function.validators = {}
+
+        function.validators.update(kwargs)
+
+        return function
+
+    return decorator

--- a/tests/test_method_args.py
+++ b/tests/test_method_args.py
@@ -1,0 +1,121 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_args(rpc_context):
+    # simple coroutine based methods
+    async def method1(request, a):
+        return a
+
+    async def method2(request, a, b, c=1):
+        return [a, b, c]
+
+    async def method3(a, b, c=1):
+        return [a, b, c]
+
+    async def method4():
+        return [1, 2, 3]
+
+    # class based methods
+    class ClassBasedView:
+        def __init__(self):
+            self.STATE = 1
+
+        async def method1(self, a):
+            assert self.STATE == 1  # make sure 'self' is always accessible
+
+            return a
+
+        async def method2(self, request, a, b, c=1):
+            assert self.STATE == 1
+
+            return [a, b, c]
+
+        async def method3(self, a, b, c=1):
+            assert self.STATE == 1
+
+            return [a, b, c]
+
+        async def method4(self):
+            assert self.STATE == 1
+
+            return [1, 2, 3]
+
+    # setup rpc and client
+    rpc_context.rpc.add_methods(
+        ('', method1),
+        ('', method2),
+        ('', method3),
+        ('', method4),
+        ('cls', ClassBasedView()),
+    )
+
+    client = await rpc_context.make_client()
+
+    # simple coroutine based methods
+    assert await client.call('method1', 1) == 1
+
+    assert await client.call('method2', [1, 2]) == [1, 2, 1]
+    assert await client.call('method2', [1, 2, 3]) == [1, 2, 3]
+    assert await client.call('method2', {'a': 1, 'b': 2, 'c': 3}) == [1, 2, 3]
+
+    assert await client.call('method3', [1, 2]) == [1, 2, 1]
+    assert await client.call('method3', [1, 2, 3]) == [1, 2, 3]
+    assert await client.call('method3', {'a': 1, 'b': 2, 'c': 3}) == [1, 2, 3]
+
+    assert await client.call('method4') == [1, 2, 3]
+    assert await client.call('method4', [5, 5, 5]) == [1, 2, 3]
+
+    # class based methods
+    assert await client.call('cls__method1', 1) == 1
+
+    assert await client.call('cls__method2', [1, 2]) == [1, 2, 1]
+    assert await client.call('cls__method2', [1, 2, 3]) == [1, 2, 3]
+
+    assert await client.call('cls__method2',
+                             {'a': 1, 'b': 2, 'c': 3}) == [1, 2, 3]
+
+    assert await client.call('cls__method3', [1, 2]) == [1, 2, 1]
+    assert await client.call('cls__method3', [1, 2, 3]) == [1, 2, 3]
+
+    assert await client.call('cls__method3',
+                             {'a': 1, 'b': 2, 'c': 3}) == [1, 2, 3]
+
+    assert await client.call('cls__method4') == [1, 2, 3]
+    assert await client.call('cls__method4', [5, 5, 5]) == [1, 2, 3]
+
+
+@pytest.mark.asyncio
+async def test_to_few_arguments(rpc_context):
+    from aiohttp_json_rpc import RpcInvalidParamsError
+
+    async def method1(request, a):
+        return a
+
+    async def method2(request, a, b, c=1):
+        return [a, b, c]
+
+    # setup rpc and client
+    rpc_context.rpc.add_methods(
+        ('', method1),
+        ('', method2),
+    )
+
+    client = await rpc_context.make_client()
+
+    # method1
+    with pytest.raises(RpcInvalidParamsError) as exc_info:
+        await client.call('method1')
+
+    assert exc_info.value.message == 'to few arguments'
+
+    # method2
+    with pytest.raises(RpcInvalidParamsError) as exc_info:
+        await client.call('method2', 1)
+
+    assert exc_info.value.message == 'to few arguments'
+
+    with pytest.raises(RpcInvalidParamsError) as exc_info:
+        await client.call('method2', {'a': 1, 'c': 1})
+
+    assert exc_info.value.message == 'to few arguments'

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -82,6 +82,7 @@ async def test_call_method(rpc_context):
     assert await client.call('add', [1, 2]) == 3
 
 
+@pytest.mark.xfail
 @pytest.mark.asyncio
 async def test_call_method_and_unpack_args(rpc_context, caplog):
     from aiohttp_json_rpc import rpc


### PR DESCRIPTION
Hi @webknjaz @ZhukovGreen,

you guys submitted `unpack_request_args` and honestly i was never very happy with this solution, but i understand the api inconveniences you want to fix.
Further i am pretty annoyed of implementing boilerplate code to check if all required args are present and have the right type.

For example:
If you want to add a simple method to add two integers you would have to do something like this

```python
async def add(request):
    try:
        a = request.params['a']
        b = request.params['b']

        assert type(a) == int
        assert type(b) == int

    except:
        raise RpcInvalidParamsError

    return a + b
```

My new solution would allow things like this:
```python
@validate(a=int, b=int)
async def add(a, b):
    return a + b

async def sub(a, b, c=1):
    return a - b -c

async def backwards_compatible_method(request):
    return request.params['a'] + request.params['b']

# client requests
>>> add(1, 2)
3

>> add('1', 2)  # wrong type
RpcInvalidParamsError

>>> sub(1)  # to few arguments
RpcInvalidParamsError
```
The validate decorator is not fully implemented yet but i will add it to the final version. This is only a proove of concept now :)

