### PR TITLE
Fix: Unclosed session when client failed to setup connection

### DIFF
--- a/aiohttp_json_rpc/client.py
+++ b/aiohttp_json_rpc/client.py
@@ -120,7 +120,13 @@ class JsonRpcClient:
         self._session = aiohttp.ClientSession(cookies=cookies, loop=self._loop)
 
         self._logger.debug('#%s: ws connect...', self._id)
-        self._ws = await self._session.ws_connect(url)
+        self._ws = None
+        try:
+            self._ws = await self._session.ws_connect(url)
+        finally:
+            if self._ws is None:
+                # Ensure session is closed when connection failed
+                await self._session.close()
         self._logger.debug('#%s: ws connected', self._id)
 
         self._message_worker = asyncio.ensure_future(self._handle_msgs())

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,5 @@
 import pytest
+import aiohttp
 
 from aiohttp_json_rpc.client import JsonRpcClient
 
@@ -63,3 +64,21 @@ async def test_client_autoconnect(rpc_context):
     assert initial_ws is client._ws
 
     await client.disconnect()
+
+
+async def test_client_connection_failure(rpc_context, unused_tcp_port_factory):
+    client = JsonRpcClient(
+        url='ws://{host}:{port}{url}'.format(
+            host=rpc_context.host, port=rpc_context.port,
+            url=rpc_context.url,
+        )
+    )
+
+    with pytest.raises(aiohttp.ClientConnectionError):
+        await client.connect_url(
+            'ws://{host}:{port}{url}'.format(
+                host=rpc_context.host, port=unused_tcp_port_factory(),
+                url=rpc_context.url,
+            )
+        )
+    assert client._session.closed is True


### PR DESCRIPTION
The following errors appear when client failed to setup connection.

```
2018-07-14 11:31:25 asyncio ERROR Unclosed client session
client_session: <aiohttp.client.ClientSession object at 0x7f1c579d10b8>
```
This fix ensures session is closed on connection failure.