### PR TITLE
Update from deprecated techniques

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -45,7 +45,7 @@ The following code implements a simple RPC server that serves the method ``ping`
 
 .. code-block:: python
 
-  from aiohttp.web import Application
+  from aiohttp.web import Application, run_app
   from aiohttp_json_rpc import JsonRpc
   import asyncio
 
@@ -63,14 +63,9 @@ The following code implements a simple RPC server that serves the method ``ping`
       )
 
       app = Application(loop=loop)
-      app.router.add_route('*', '/', rpc)
+      app.router.add_route('*', '/', rpc.handle_request)
 
-      handler = app.make_handler()
-
-      server = loop.run_until_complete(
-          loop.create_server(handler, '0.0.0.0', 8080))
-
-      loop.run_forever()
+      run_app(app, host='0.0.0.0', port=8080)
 
 
 Client (JS)

--- a/aiohttp_json_rpc/rpc.py
+++ b/aiohttp_json_rpc/rpc.py
@@ -247,7 +247,10 @@ class JsonRpc(object):
 
             self.topics[name] = func
 
-    async def __call__(self, request):
+    def __call__(self, request):
+        return self.handle_request(request)
+
+    async def handle_request(self, request):
         # prepare request
         request.rpc = self
         self.auth_backend.prepare_request(request)

--- a/dev-server/dev-server
+++ b/dev-server/dev-server
@@ -50,8 +50,10 @@ app.router.add_static('/static', 'dev-server/static', show_index=True)
 app.router.add_get('/rpc', rpc)
 app.router.add_get('/', index)
 
-loop.run_until_complete(
-    loop.create_server(app.make_handler(), 'localhost', 8080))
+runner = web.AppRunner(app)
+loop.run_until_complete(runner.setup())
+site = web.TCPSite(runner, 'localhost', 8080)
+loop.run_until_complete(site.start())
 
 loop.run_until_complete(setup_client(client))
 

--- a/examples/base_example.py
+++ b/examples/base_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # Author: Florian Scherf <f.scherf@pengutronix.de>
 
-from aiohttp.web import Application
+from aiohttp.web import Application, run_app
 from aiohttp_json_rpc import JsonRpc
 import asyncio
 
@@ -21,11 +21,6 @@ if __name__ == '__main__':
     )
 
     app = Application(loop=loop)
-    app.router.add_route('*', '/', rpc)
+    app.router.add_route('*', '/', rpc.handle_request)
 
-    handler = app.make_handler()
-
-    server = loop.run_until_complete(
-        loop.create_server(handler, '0.0.0.0', 8080))
-
-    loop.run_forever()
+    run_app(app, host='0.0.0.0', port=8080)

--- a/examples/django_example_project/server.py
+++ b/examples/django_example_project/server.py
@@ -3,7 +3,7 @@
 # Author: Florian Scherf <f.scherf@pengutronix.de>
 
 from django_example_project.wsgi import application as django_app
-from aiohttp.web import Application
+from aiohttp.web import Application, run_app
 from aiohttp_wsgi import WSGIHandler
 from aiohttp_json_rpc import JsonRpc
 from aiohttp_json_rpc.auth.django import DjangoAuthBackend
@@ -20,12 +20,7 @@ if __name__ == '__main__':
         ('', 'django_example_app.rpc')
     )
 
-    app.router.add_route('*', '/rpc', rpc)
+    app.router.add_route('*', '/rpc', rpc.handle_request)
     app.router.add_route('*', '/{path_info:.*}', wsgi_handler.handle_request)
 
-    handler = app.make_handler()
-
-    server = loop.run_until_complete(
-        loop.create_server(handler, '0.0.0.0', 8080))
-
-    loop.run_forever()
+    run_app(app, host='0.0.0.0', port=8080)

--- a/examples/passwd_example.py
+++ b/examples/passwd_example.py
@@ -5,19 +5,17 @@
 from aiohttp_json_rpc.auth.passwd import PasswdAuthBackend
 from aiohttp_json_rpc.auth import login_required
 from aiohttp_json_rpc import JsonRpc
-from aiohttp.web import Application
+from aiohttp.web import Application, run_app
 import asyncio
 import os
 
 
-@asyncio.coroutine
-def ping(request):
+async def ping(request):
     return 'pong'
 
 
 @login_required
-@asyncio.coroutine
-def pong(request):
+async def pong(request):
     return 'ping'
 
 
@@ -34,11 +32,6 @@ if __name__ == '__main__':
     )
 
     app = Application(loop=loop)
-    app.router.add_route('*', '/', rpc)
+    app.router.add_route('*', '/', rpc.handle_request)
 
-    handler = app.make_handler()
-
-    server = loop.run_until_complete(
-        loop.create_server(handler, '0.0.0.0', 8080))
-
-    loop.run_forever()
+    run_app(app, host='0.0.0.0', port=8080)

--- a/examples/publish_subscribe_example.py
+++ b/examples/publish_subscribe_example.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 # Author: Florian Scherf <f.scherf@pengutronix.de>
 
-from aiohttp.web import Application
+from aiohttp.web import Application, run_app
 from aiohttp_json_rpc import JsonRpc
 import datetime
 import asyncio
@@ -29,11 +29,6 @@ if __name__ == '__main__':
     loop.create_task(clock(rpc))
 
     app = Application(loop=loop)
-    app.router.add_route('*', '/', rpc)
+    app.router.add_route('*', '/', rpc.handle_request)
 
-    handler = app.make_handler()
-
-    server = loop.run_until_complete(
-        loop.create_server(handler, '0.0.0.0', 8080))
-
-    loop.run_forever()
+    run_app(app, host='0.0.0.0', port=8080)


### PR DESCRIPTION
aiohttp 3 has deprecated a few things, and I've detailed here what's been updated to address this:
- `loop` parameter to `Application.__init__()` is deprecated, and its usage has been removed from examples and tests.
- Passing a request handler to `Application.add_route` which is not a coroutine function is deprecated, and thus a warning is raised when passing a `JsonRpc` instance to it - now to avoid this warning, the `JsonRpc.handle_request` instance method can be passed to it, which is identical the previous `__call__` function. The `__call__` function now acts as an alias for `JsonRpc.handle_request` for backwards compatibility.
- Usage of `Application.make_handler` to asynchronously start the server is deprecated in favour of the [`AppRunner` API](https://docs.aiohttp.org/en/stable/web_reference.html#aiohttp.web.AppRunner).

I'll make a note of what I've done in examples: all examples (including in the README) were creating a server through the low-level `Application.make_handler()` and `loop.create_server()` API, then issuing a blocking `loop.run_forever()` call to run it. Since this is a blocking call, I replaced this with the usage of `aiohttp.web.run_app()`. However, I understand a lot of usages of this library will require an asynchronous, non-blocking way of starting the RPC server, so perhaps providing the examples with a usage of the `AppRunner` API is more suitable. I will leave it up to you to decide @fscherf! :smile: