### PR TITLE
Fix the Python client example to remove /rpc

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,10 +119,10 @@ There's also Python client, which can be used as follows:
 
 
   async def ping_json_rpc():
-      """Connect to ws://localhost:8080/rpc, call ping() and disconnect."""
+      """Connect to ws://localhost:8080/, call ping() and disconnect."""
       rpc_client = JsonRpcClient()
       try:
-          await rpc_client.connect('localhost', 8080, '/rpc')
+          await rpc_client.connect('localhost', 8080)
           call_result = await rpc_client.call('ping')
           print(call_result)  # prints 'pong' (if that's return val of ping)
       finally:


### PR DESCRIPTION
As described in #42, there is an issue when you use the example from the README. The example server creates a server on `localhost:8080` while the example client tries to connect to `localhost:8080/rpc`, giving an error.

To make my client work, @fscherf told me to remove the `/rpc` from the adress, and it worked, so I'm creating this quick PR to prevent others from getting the same error.