### PR TITLE
Remove the lenght of arguments conditions

### DIFF
--- a/aiohttp_json_rpc/rpc.py
+++ b/aiohttp_json_rpc/rpc.py
@@ -51,7 +51,7 @@ class JsonRpcMethod:
         # required args
         self.required_args = copy(self.args)
 
-        if not (len(self.args) == 1 and self.defaults is None):
+        if not (self.defaults is None):
             self.required_args = [
                 i for i in self.args[:-len(self.defaults or ())]
                 if i not in self.CREDENTIAL_KEYS


### PR DESCRIPTION
I don't know why `len(self.args) == 1` is used for, maybe it was supposed to be `>=`, but when I remove this, the issue described in #44 is fixed.

Thanks to @calebj for helping me with this.