### PR TITLE
Fix duplicate logs

### DIFF
--- a/aiohttp_json_rpc/rpc.py
+++ b/aiohttp_json_rpc/rpc.py
@@ -331,7 +331,7 @@ class JsonRpc(object):
                 )
 
             except Exception as error:
-                logging.error(error, exc_info=True)
+                self.logger.error(error, exc_info=True)
 
                 await self._ws_send_str(http_request, encode_error(
                     RpcInternalError(msg_id=msg.data.get('id', None))


### PR DESCRIPTION
If a program is using it's own logger, and an RPC function runs into an error, it starts duplicating logs due to it using `logging` instead of `self.logger`.