### PR TITLE
Use the passed-in name for constructing repr() of JsonMethod.

### DIFF
--- a/aiohttp_json_rpc/auth/django.py
+++ b/aiohttp_json_rpc/auth/django.py
@@ -213,7 +213,7 @@ class DjangoAuthBackend(AuthBackend):
 
                 if action in ('view', 'add', 'change', 'delete', ):
                     request.methods[method_name] = JsonRpcMethod(
-                        self.handle_orm_call)
+                        self.handle_orm_call, method_name)
 
         # rpc defined methods
         for name, method in request.rpc.methods.items():

--- a/aiohttp_json_rpc/rpc.py
+++ b/aiohttp_json_rpc/rpc.py
@@ -31,8 +31,9 @@ from .exceptions import (
 class JsonRpcMethod:
     CREDENTIAL_KEYS = ['request', 'worker_pool']
 
-    def __init__(self, method):
+    def __init__(self, method, name=None):
         self.method = method
+        self.name = name
 
         # method introspection
         try:
@@ -80,7 +81,7 @@ class JsonRpcMethod:
         ]
 
         self._repr_str = 'JsonRpcMethod({}({}))'.format(
-            self.method.__name__,
+            name or self.method.__name__,
             ', '.join(args),
         )
 
@@ -179,7 +180,7 @@ class JsonRpc(object):
         if prefix:
             name = '{}__{}'.format(prefix, name)
 
-        self.methods[name] = JsonRpcMethod(method)
+        self.methods[name] = JsonRpcMethod(method, name)
 
     def _add_methods_from_object(self, obj, prefix='', ignore=[]):
         for attr_name in dir(obj):

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -101,3 +101,19 @@ async def test_method_names(rpc_context, caplog):
 
     assert await client.call('method1') == 'method1'
     assert await client.call('method2') == 'method2'
+
+    assert 'method1' in repr(rpc_context.rpc.methods['method1'])
+
+
+@pytest.mark.asyncio
+async def test_partial_method(rpc_context, caplog):
+    from functools import partial
+
+    async def pong(request, msg):
+        return msg
+
+    rpc_context.rpc.add_methods(
+        ('', partial(pong, msg="pong"), "pong"),
+    )
+
+    assert 'pong' in repr(rpc_context.rpc.methods['pong'])


### PR DESCRIPTION
This lets users pass in callables that don't have a `__name__` (like instances of `functools.partial`).